### PR TITLE
add agent queue tag name

### DIFF
--- a/bin/slurmjob.sh
+++ b/bin/slurmjob.sh
@@ -4,9 +4,10 @@
 #SBATCH --reservation=clima
 
 BUILDKITE_PATH=/groups/esm/climaci
+BUILDKITE_QUEUE=central
 
 ${BUILDKITE_PATH}/bin/buildkite-agent start \
   --name "central-$1-%n" \
   --config "${BUILDKITE_PATH}/buildkite-agent.cfg" \
   --acquire-job "$2" \
-  --tags "jobid=${SLURM_JOB_ID},config=$1,ntasks=${SLURM_NTASKS}"
+  --tags "jobid=${SLURM_JOB_ID},queue=${BUILDKITE_QUEUE},config=$1,ntasks=${SLURM_NTASKS}"


### PR DESCRIPTION
apparently setting these tags on the cli overrides the defaults specified in the config file