### PR TITLE
add support for JULIA_VERSION environment variable

### DIFF
--- a/hooks/environment
+++ b/hooks/environment
@@ -24,7 +24,7 @@ case "${BUILDKITE_AGENT_META_DATA_CONFIG}" in
 
     "cpu")
         echo "--- cpu configuration"
-        module load julia/1.4.2
+        module load julia/${JULIA_VERSION:=1.4.2}
         module load openmpi/4.0.3 hdf5/1.10.1 netcdf-c/4.6.1
 
         export JULIA_CUDA_USE_BINARYBUILDER=false
@@ -35,7 +35,7 @@ case "${BUILDKITE_AGENT_META_DATA_CONFIG}" in
 
     "cpu-test")
         echo "--- cpu test configuration"
-        module load julia/1.5.1
+        module load julia/${JULIA_VERSION:=1.5.1}
         module load openmpi/4.0.4 hdf5/1.10.1 netcdf-c/4.6.1
 
         export JULIA_CUDA_USE_BINARYBUILDER=false
@@ -46,7 +46,7 @@ case "${BUILDKITE_AGENT_META_DATA_CONFIG}" in
 
     "gpu")
         echo "--- gpu configuration"
-        module load julia/1.4.2
+        module load julia/${JULIA_VERSION:=1.4.2}
         module load cuda/10.0 openmpi/4.0.3_cuda-10.0 hdf5/1.10.1 netcdf-c/4.6.1
 
         export JULIA_CUDA_USE_BINARYBUILDER=false
@@ -60,7 +60,7 @@ case "${BUILDKITE_AGENT_META_DATA_CONFIG}" in
 
     "gpu-test")
         echo "--- gpu test configuration"
-        module load julia/1.5.1
+        module load julia/${JULIA_VERSION:=1.5.1}
         module load cuda/10.2 openmpi/4.0.4_cuda-10.2 hdf5/1.10.1 netcdf-c/4.6.1
 
         export JULIA_CUDA_USE_BINARYBUILDER=false


### PR DESCRIPTION
This should make it easier to specify versions, as an `env` can be specified at the top level of the pipeline.yml to apply to all steps.