### PR TITLE
Some updates/clean ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Run [Buildkite pipelines](https://buildkite.com/) on a [Slurm cluster](https://s
 
 The basic idea is that each Buildkite job is run inside a Slurm job: the Slurm job runs the Buildkite agent with the [`--acquire-job`](https://buildkite.com/docs/agent/v3/cli-start#acquire-job) option, which ensures that only the specific Buildkite job is scheduled, and is terminated and exits once complete.
 
-Our Slurm cluster is not web-accessible, so we are unable to use webhooks to schedule the Slurm jobs. Instead poll the Buildkite API (via [`bin/poll.py`](https://github.com/CliMA/slurm-buildkite/blob/master/bin/poll.py)) via a cron job running on the cluser login node ([`bin/cron.sh`]((https://github.com/CliMA/slurm-buildkite/blob/master/bin/cron.sh)) at a regular interval (currently every minute). This does the following:
+Our Slurm cluster is not web-accessible, so we are unable to use webhooks to schedule the Slurm jobs. Instead poll the Buildkite API (via [`bin/poll.py`](https://github.com/CliMA/slurm-buildkite/blob/master/bin/poll.py)) via a cron job running on the cluster login node ([`bin/cron.sh`]((https://github.com/CliMA/slurm-buildkite/blob/master/bin/cron.sh)) at a regular interval (currently every minute). This does the following:
 
 1. Get a list of the Buildkite jobs which are currently queued or running on the cluster via [`squeue`](https://slurm.schedmd.com/squeue.html). We check this by using a specific job name (`buildkite`), and storing the Buildkite job id in the Slurm job comment.
 
@@ -27,3 +27,10 @@ agents:
   slurm_tasks_per_node: 2
 ```
 would pass the options `--nodes=1 --tasks-per-node=2`.
+
+## Installing/updating a buildkite agent
+
+To install or update the buildkite agent, acquire a copy from the [release
+page](https://github.com/buildkite/agent/releases/) on GitHub. Download the
+Linux x86 version, unzip the archive, and copy the `buildkite-agent` executable
+in the `bin` folder

--- a/bin/poll.py
+++ b/bin/poll.py
@@ -38,8 +38,8 @@ def day_ago_utc():
     return (datetime.utcnow() - timedelta(days=1)).replace(microsecond=0).isoformat() + 'Z'
 
 # What SLURM partition to use by default depending on the queue
-DEFAULT_PARTITIONS = {"default": "default", "central": "any", "new-central": "expansion"}
-DEFAULT_GPU_PARTITIONS = {"default": "default", "central": "any", "new-central": "gpu"}
+DEFAULT_PARTITIONS = {"default": "default", "new-central": "any", "new-central": "expansion"}
+DEFAULT_GPU_PARTITIONS = {"default": "default", "new-central": "any", "new-central": "gpu"}
 
 def all_started_builds():
     since = hours_ago_utc(nhours=48)

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -13,7 +13,7 @@ case "${BUILDKITE_AGENT_META_DATA_CONFIG}" in
         mkdir -p ${CI_BUILD_DIR} && cd ${CI_BUILD_DIR}
 
         if [ ! -d "${BUILDKITE_BUILD_CHECKOUT_PATH}/.git" ]; then
-            echo "--- Init clone and checkout" 
+            echo "--- Init clone and checkout"
             COUNT=1
             while true; do
                 git clone ${BUILDKITE_GIT_CLONE_FLAGS} ${BUILDKITE_REPO} "${BUILDKITE_BUILD_CHECKOUT_PATH}"
@@ -26,9 +26,9 @@ case "${BUILDKITE_AGENT_META_DATA_CONFIG}" in
                 else
                     echo "Clone ${BUILDKITE_REPO} failed, retrying..."
                     sleep 30s
-                fi 
+                fi
                 let COUNT=COUNT+1
-            done 
+            done
             cd "${BUILDKITE_BUILD_CHECKOUT_PATH}"
             if [ "$BUILDKITE_COMMIT" = "HEAD" ]; then
                 git checkout -f "${BUILDKITE_BRANCH}"
@@ -40,11 +40,11 @@ case "${BUILDKITE_AGENT_META_DATA_CONFIG}" in
                 echo "Sending Git commit information to Buildkite"
                 git --no-pager show HEAD -s --format=fuller --no-color -- | buildkite-agent meta-data set "buildkite:git:commit"
             fi
-                
+
         else
             echo "--- Using cached git repo ${BUILDKITE_BUILD_CHECKOUT_PATH}"
             cd "${BUILDKITE_BUILD_CHECKOUT_PATH}"
-        fi 
+        fi
         ;;
 
     *)

--- a/hooks/environment
+++ b/hooks/environment
@@ -20,8 +20,9 @@ export CI_BUILD_DIR="${BUILDKITE_BUILD_PATH}/${BUILDKITE_PIPELINE_SLUG}/${BUILDK
 export BUILDKITE_BUILD_CHECKOUT_PATH="${CI_BUILD_DIR}/${BUILDKITE_PIPELINE_SLUG}"
 export BUILDKITE_API_TOKEN=$(cat "${SLURM_BUILDKITE_PATH}/.buildkite_token")
 
+# Create temporary folder created in `environment` for all the MPI processes
 export TMPDIR="/tmp/slurm-${SLURM_JOB_ID}"
-srun --ntasks-per-node=1 --ntasks=${SLURM_JOB_NUM_NODES} mkdir -p "${TMPDIR}"
+pdsh -w $SLURM_NODELIST mkdir -p "${TMPDIR}"
 printenv TMPDIR
 
 ulimit -c unlimited

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -14,6 +14,7 @@ set -v
 # Since the output folder is in /scratch, we must change this setting every time
 # scratch is purged
 chmod g+s $BUILDKITE_BUILD_PATH
+chgrp hpc_esm $BUILDKITE_BUILD_PATH
 
 case "${BUILDKITE_AGENT_META_DATA_CONFIG}" in
     # standard configurations run with shared base depot

--- a/hooks/pre-exit
+++ b/hooks/pre-exit
@@ -8,4 +8,5 @@
 set -euo pipefail # exit on failure or unset variable
 
 df -h /tmp/
-srun --ntasks-per-node=1 --ntasks=${SLURM_JOB_NUM_NODES} rm -rf "/tmp/slurm_${SLURM_JOB_ID}"
+# Tear down the temporary folder created in `environment` for all the MPI processes
+pdsh -w $SLURM_NODELIST rm -rf "/tmp/slurm_${SLURM_JOB_ID}"


### PR DESCRIPTION
Mostly routine clean ups. The main change worth noting is moving from `srun` to `pdsh` to create and remove the TMPDIR on other nodes. This should make the system more robust with respect to SLURM time outs.