### PR TITLE
Unify slurm-buildkite for Caltech HPC and Clima GPU Server

### DIFF
--- a/bin/cron.sh
+++ b/bin/cron.sh
@@ -1,25 +1,24 @@
 #!/bin/bash
 source /etc/bashrc
 
-if [[ "$(hostname)" != "login1.cm.cluster" &&  "$(hostname)" != "login3.cm.cluster" ]]; then
-    exit 0
-fi
-
-export BUILDKITE_PATH="/groups/esm/slurm-buildkite"
-
 # To manage old and new at the same time, we define different queues and we run this
 # script on both login1 and login3
-if [[ "$(hostname)" == "login1.cm.cluster" ]]; then
-    # login1 is our legacy node
-    export BUILDKITE_QUEUE='central'
-else
-    # login3 is our new system
-    export BUILDKITE_QUEUE='new-central'
-fi
+case "$(hostname)" in
+    "login3.cm.cluster")
+        export BUILDKITE_PATH="/groups/esm/slurm-buildkite"
+        export BUILDKITE_QUEUE='new-central'
+        ;;
+    "clima.gps.caltech.edu")
+        export BUILDKITE_PATH="/clima/slurm-buildkite"
+        export BUILDKITE_QUEUE='clima'
+        ;;
+esac
 
-cd $BUILDKITE_PATH
+# cd $BUILDKITE_PATH
 
 DATE="$(date +\%Y-\%m-\%d)"
 mkdir -p "logs/$DATE"
 
-bin/poll.py &>> "logs/$DATE/cron"
+export DEBUG_SLURM_BUILDKITE=true
+
+bin/poll.py #&>> "logs/$DATE/cron"

--- a/bin/cron.sh
+++ b/bin/cron.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 source /etc/bashrc
 
-# To manage old and new at the same time, we define different queues and we run this
-# script on both login1 and login3
 case "$(hostname)" in
-    "login3.cm.cluster")
+    "login1.cm.cluster"|"login3.cm.cluster")
         export BUILDKITE_PATH="/groups/esm/slurm-buildkite"
         export BUILDKITE_QUEUE='new-central'
         ;;
@@ -14,11 +12,9 @@ case "$(hostname)" in
         ;;
 esac
 
-# cd $BUILDKITE_PATH
+cd $BUILDKITE_PATH
 
 DATE="$(date +\%Y-\%m-\%d)"
 mkdir -p "logs/$DATE"
 
-export DEBUG_SLURM_BUILDKITE=true
-
-bin/poll.py #&>> "logs/$DATE/cron"
+bin/poll.py &>> "logs/$DATE/cron"

--- a/bin/slurmjob.sh
+++ b/bin/slurmjob.sh
@@ -3,18 +3,20 @@
 #SBATCH --job-name=buildkite
 #SBATCH --reservation=clima
 
+# TODO: Remove defaults for BUILDKITE_PATH and BUILDKITE_QUEUE
 BUILDKITE_PATH=${BUILDKITE_PATH:=/groups/esm/slurm-buildkite}
 BUILDKITE_QUEUE=${BUILDKITE_QUEUE:=new-central}
 PATH="${BUILDKITE_PATH}/bin:$PATH"
 
-TAGS="jobid=${SLURM_JOB_ID},queue=${BUILDKITE_QUEUE},config=$1,ntasks=${SLURM_NTASKS}"
-if [ $# -ge 3 ]; then
-    TAGS="$TAGS,modules=$3"
+# TODO: Most of these tags don't seem to be get used
+# TODO: We could set the modulepath in the tags here, or it could be determined by queue
+TAGS="jobid=${SLURM_JOB_ID},queue=${BUILDKITE_QUEUE},ntasks=${SLURM_NTASKS}"
+if [ $# -ge 2 ]; then
+    TAGS="$TAGS,modules=$2"
 fi
-
 
 ${BUILDKITE_PATH}/bin/buildkite-agent start \
   --name "$BUILDKITE_QUEUE-$1-%n" \
   --config "${BUILDKITE_PATH}/buildkite-agent.cfg" \
-  --acquire-job "$2" \
+  --acquire-job "$1" \
   --tags "$TAGS"

--- a/hooks/checkout
+++ b/hooks/checkout
@@ -1,56 +1,24 @@
 #!/bin/bash
 
-# The `checkout` hook script will replace the default checkout routine of the
-# bootstrap.sh script. You can use this hook to do your own SCM checkout
-# behaviour
-
 set -euo pipefail # exit on failure or unset variable
 set -v
 
-case "${BUILDKITE_AGENT_META_DATA_CONFIG}" in
-    init|default)
-        echo "--- Init working build directory"
-        mkdir -p ${CI_BUILD_DIR} && cd ${CI_BUILD_DIR}
-
-        if [ ! -d "${BUILDKITE_BUILD_CHECKOUT_PATH}/.git" ]; then
-            echo "--- Init clone and checkout" 
-            COUNT=1
-            while true; do
-                git clone ${BUILDKITE_GIT_CLONE_FLAGS} ${BUILDKITE_REPO} "${BUILDKITE_BUILD_CHECKOUT_PATH}"
-                if [ $? -eq 0 ]; then
-                    break
-                fi
-                if [[ $COUNT -ge 3 ]]; then
-                    echo "Clone ${BUILDKITE_REPO} failed after 3 attempts"
-                    exit 1
-                else
-                    echo "Clone ${BUILDKITE_REPO} failed, retrying..."
-                    sleep 30s
-                fi 
-                let COUNT=COUNT+1
-            done 
-            cd "${BUILDKITE_BUILD_CHECKOUT_PATH}"
-            if [ "$BUILDKITE_COMMIT" = "HEAD" ]; then
-                git checkout -f "${BUILDKITE_BRANCH}"
-            else
-                git checkout -f "${BUILDKITE_COMMIT}"
-            fi
-            # emulate https://github.com/buildkite/agent/blob/7e0166eebed5bf3cc289edae97145803429e75f9/bootstrap/bootstrap.go#L1448-L1458
-            if ! buildkite-agent meta-data exists "buildkite:git:commit" ; then
-                echo "Sending Git commit information to Buildkite"
-                git --no-pager show HEAD -s --format=fuller --no-color -- | buildkite-agent meta-data set "buildkite:git:commit"
-            fi
-                
+if [ ! -d "${BUILDKITE_BUILD_CHECKOUT_PATH}/.git" ]; then
+    echo "--- Init clone and checkout" 
+    COUNT=1
+    while true; do
+        git clone ${BUILDKITE_GIT_CLONE_FLAGS} ${BUILDKITE_REPO} "${BUILDKITE_BUILD_CHECKOUT_PATH}"
+        if [ $? -eq 0 ]; then
+            break
+        fi
+        if [[ $COUNT -ge 3 ]]; then
+            echo "Clone ${BUILDKITE_REPO} failed after 3 attempts"
+            exit 1
         else
-            echo "--- Using cached git repo ${BUILDKITE_BUILD_CHECKOUT_PATH}"
-            cd "${BUILDKITE_BUILD_CHECKOUT_PATH}"
+            echo "Clone ${BUILDKITE_REPO} failed, retrying..."
+            sleep 30s
         fi 
-        ;;
-
-    *)
-        echo "--- Using cached git repo ${BUILDKITE_BUILD_CHECKOUT_PATH}"
-        cd "${BUILDKITE_BUILD_CHECKOUT_PATH}"
-        ;;
-esac
-
+        let COUNT=COUNT+1
+    done
+fi
 set +v

--- a/hooks/environment
+++ b/hooks/environment
@@ -31,134 +31,15 @@ echo "--- Slurm Job ID: ${SLURM_JOB_ID}"
 scontrol show job ${SLURM_JOB_ID} --details
 scontrol show node ${SLURM_JOB_NODELIST}
 
+# TODO: Properly set the modulepath depending on queue
 if $(grep -q "Red Hat" /etc/redhat-release);  then
-    echo "We are on a RedHat 9 node"
-
-    # We are on rhel9 nodes, we also want our modules
+    # MODULEPATH for Caltech HPC
     export MODULEPATH="/groups/esm/modules:$MODULEPATH"
-
     module load git/2.39.3-gcc-11.3.1-zfr3sti
-else
-    # We are on the CentOS nodes
-    module load git/2.26.0
 fi
-
 
 # this is set to avoid rare race conditions on the same node with concurrent (step) jobs
 export OMPI_MCA_orte_tmpdir_base="$TMPDIR"
-
-case "${BUILDKITE_AGENT_META_DATA_CONFIG}" in
-    # standard configurations
-   ""|default)
-        module load ${BUILDKITE_AGENT_META_DATA_MODULES:-}
-        export JULIA_DEPOT_PATH="${JULIA_DEPOT_PATH:-$CI_BUILD_DIR/depot/default}:${SHARED_DEPOT}"
-        ;;
-
-    init)
-        echo "--- init env configuration"
-        ;;
-
-    cpu)
-        echo "--- cpu env configuration"
-        module load singularity/3.5.2
-        module load python3/${PYTHON_VERSION:=3.8.5}
-        module load julia/${JULIA_VERSION:=1.10.0}
-        if [ "${MPI_IMPL:=mpich}" == "mpich" ]; then
-            module load mpich/${MPICH_VERSION:=4.0.0} hdf5/1.12.1 netcdf-c/4.8.1
-        else
-            module load openmpi/${OPENMPI_VERSION:=4.1.1}
-            if [ "${OPENMPI_VERSION:=4.1.1}" == "4.1.1" ]; then
-                module load hdf5/1.12.1-ompi411
-            else
-                module load hdf5/1.12.1
-            fi
-        fi
-
-        export JULIA_DEPOT_PATH="${JULIA_DEPOT_PATH:=$CI_BUILD_DIR/depot/cpu}"
-        export JULIA_CUDA_USE_BINARYBUILDER=false
-        export JULIA_MPI_BINARY=system
-        export JULIA_HDF5_PATH=""
-
-        # this is set to not use shared memory segments as a btl transport
-        # they do not get cleaned up on the cluster
-        # export OMPI_MCA_btl="self,tcp"
-        export CLIMATEMACHINE_SETTINGS_OUTPUT_DIR="${CI_BUILD_DIR}/output/${BUILDKITE_STEP_KEY}"
-
-        echo "--- slurm job configuration"
-        sacct -a -X -j ${SLURM_JOB_ID} --format=JobID,AllocCPUs,nnodes,nodelist
-        ;;
-
-    cpu-test)
-        echo "--- cpu test env configuration"
-        module load singularity/3.5.2
-        module load python3/${PYTHON_VERSION:=3.8.5}
-        module load julia/${JULIA_VERSION:=1.10.0}
-        if [ "${MPI_IMPL:=mpich}" == "mpich" ]; then
-            module load mpich/${MPICH_VERSION:=4.0.0} hdf5/1.12.1 netcdf-c/4.8.1
-        else
-            module load openmpi/${OPENMPI_VERSION:=4.1.1} hdf5/1.12.1-ompi411
-        fi
-
-        export JULIA_DEPOT_PATH:="${CI_BUILD_DIR}/depot/cpu"
-        export JULIA_CUDA_USE_BINARYBUILDER=false
-        export JULIA_MPI_BINARY=system
-        export JULIA_HDF5_PATH=""
-
-        # export OMPI_MCA_btl="self,tcp"
-        export OMPI_MCA_orte_tmpdir_base="/tmp/slurm-buildkite/${BUILDKITE_STEP_KEY}"
-        export CLIMATEMACHINE_SETTINGS_OUTPUT_DIR="${CI_BUILD_DIR}/output/${BUILDKITE_STEP_KEY}"
-
-        echo "--- slurm job configuration"
-        sacct -a -X -j ${SLURM_JOB_ID} --format=JobID,AllocCPUs,nnodes,nodelist
-        ;;
-
-    gpu)
-        echo "--- gpu env configuration"
-        module load singularity/3.5.2
-        module load python3/${PYTHON_VERSION:=3.8.5}
-        module load julia/${JULIA_VERSION:=1.10.0}
-        module load cuda/${CUDA_VERSION:=12.2} openmpi/${OPENMPI_VERSION:=4.0.4}_cuda-${CUDA_VERSION:=12.2} hdf5/1.10.1 netcdf-c/4.6.1
-
-        export JULIA_DEPOT_PATH="${JUIA_DEPOT_PATH:=$CI_BUILD_DIR/depot/gpu}"
-        export JULIA_CUDA_USE_BINARYBUILDER=false
-        export JULIA_MPI_BINARY=system
-
-        # export OMPI_MCA_btl="self,tcp"
-        export OMPI_MCA_orte_tmpdir_base="/tmp/slurm-buildkite/${BUILDKITE_STEP_KEY}"
-        export CLIMATEMACHINE_SETTINGS_OUTPUT_DIR="${CI_BUILD_DIR}/output/${BUILDKITE_STEP_KEY}"
-
-        echo "--- slurm job configuration"
-        sacct -a -X -j ${SLURM_JOB_ID} --format=JobID,AllocCPUs,nnodes,nodelist
-
-        echo "--- gpu device configuration"
-        nvidia-smi -q
-        ;;
-
-    gpu-test)
-        echo "--- gpu test env configuration"
-        module load singularity/3.5.2
-        module load python3/${PYTHON_VERSION:=3.8.5}
-        module load julia/${JULIA_VERSION:=1.10.0}
-        module load cuda/${CUDA_VERSION:=12.2} openmpi/${OPENMPI_VERSION:=4.0.4}_cuda-${CUDA_VERSION:=12.2} hdf5/1.10.1 netcdf-c/4.6.1
-
-        export JULIA_DEPOT_PATH="${CI_BUILD_DIR}/depot/gpu"
-        export JULIA_CUDA_USE_BINARYBUILDER=false
-        export JULIA_MPI_BINARY=system
-
-        # export OMPI_MCA_btl="self,tcp"
-        export OMPI_MCA_orte_tmpdir_base="/tmp/slurm-buildkite/${BUILDKITE_STEP_KEY}"
-
-        echo "--- slurm job configuration"
-        sacct -a -X -j ${SLURM_JOB_ID} --format=JobID,AllocCPUs,nnodes,nodelist
-
-        echo "--- gpu test device configuration"
-        nvidia-smi -q
-        ;;
-
-    *)
-        echo "agent config must init, cpu or gpu"
-        ;;
-esac
 
 # From https://stackoverflow.com/a/51141872, to remove colors from modules
 # (Color tags mess up the builkite log)
@@ -169,11 +50,6 @@ printf -- '--- ' && echo $module_list
 if [ -n "${SLURM_GPUS_ON_NODE:-}" ]; then
     echo "--- GPUs available on ${HOSTNAME}"
     nvidia-smi -L
-fi
-
-# Add pipeline specific ENV variables
-if [ "$BUILDKITE_PIPELINE_NAME" == "ClimateMachine-Docs" ]; then
-    export DOCUMENTER_KEY=$(cat "$BUILDKITE_PATH/.climatemachine_documenter_key")
 fi
 
 export SLACK_TOKEN=$(cat "$BUILDKITE_PATH/.slack_token")

--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -15,13 +15,4 @@ set -v
 # scratch is purged
 chmod g+s $BUILDKITE_BUILD_PATH
 
-case "${BUILDKITE_AGENT_META_DATA_CONFIG}" in
-    # standard configurations run with shared base depot
-    # but temporary prefix for each run
-    cpu|cpu-test|gpu|gpu-test)
-        #TMP_DEPOT=`mktemp -d` || exit 1
-        #export JULIA_DEPOT_PATH="${TMP_DEPOT}:${JULIA_DEPOT_PATH}"
-        ;;
-esac
-
 set +v


### PR DESCRIPTION
The hooks are untested, I will test them tonight/early tomorrow.

### Content
poll.py
- Replaced loop over `agent_query_rules` with simpler logic. It now gets parsed into a dict that we extract values from
- Fixed slurm flags not being passed to slurm. In the yaml they now take the form `slurm_exclusive: true #(or True)` 
- Replaced `.format()` with f-strings, cleaned up some logging
- No longer require excluded nodes from file
- Changed `gpu_is_requested` to loop over all slurm_args at once, behavior should be unchanged

Hooks
- Removed old config/env system 

questions and remaining work- these roughly correspond to TODOs in the changes:
- Should the slurm comment just contain the buildkite link? It currenly has duplicate info with format <buildkite_jobid>___<buildkite_link>
- Should poll.py log all new jobs, regardless of queue? poll.py also currently creates a slurmlog for each build, even if it doesn't get run because it isn't on the same queue
- 
- Remove defaults for BUILDKITE_QUEUE and BUILDKITE_PATH
- Clean up tags in slurmjob.sh
- Set modulepath properly - most likely using [buildkite agent tags](https://buildkite.com/docs/agent/v3/cli-start#tags) 