### PR TITLE
Fix bin/mirror.sh to not exit on error

### DIFF
--- a/bin/mirror.sh
+++ b/bin/mirror.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-set -xe
+set -x
 
 case "$BUILDKITE_AGENT_META_DATA_QUEUE" in
     "new-central")


### PR DESCRIPTION
Example [build](https://buildkite.com/clima/sync-artifacts-to-clima/builds/15#019369a1-363c-42db-8b65-09c06d3c3f87) where rsync errors but the script continues to the `sed`