### PR TITLE
Update instructions for should_skip_buildkite

### DIFF
--- a/bin/should_skip_buildkite_pipeline_upload.sh
+++ b/bin/should_skip_buildkite_pipeline_upload.sh
@@ -7,17 +7,17 @@
 
 # To be used in the buildkite step as:
 #
-# agents:
-#     queue: new-central
-#     slurm_qos: "debug"
-#     slurm_time: "00:05:00"
-
 # steps:
 #   - label: "Skip CI If we are only modifying md or .github files"
 #     key: "skip_ci"
 #     command:
 #       - should_skip_buildkite_pipeline_upload.sh
-#     soft_fail: true
+#     soft_fail:
+#         - exit_status: 1
+#     agents:
+#         queue: new-central
+#         slurm_qos: "debug"
+#         slurm_time: "00:05:00"
 
 #   - wait:
 #     continue_on_failure: true
@@ -27,5 +27,9 @@
 #       if [ $$(buildkite-agent step get "outcome" --step "skip_ci") == "passed" ]; then
 #         buildkite-agent pipeline upload .buildkite/pipeline.yml
 #       fi
+#     agents:
+#         queue: new-central
+#         slurm_qos: "debug"
+#         slurm_time: "00:05:00"
 
 git diff origin/main --name-only | grep -v ".md" | grep -v ".github" -c && exit 0 || exit 1


### PR DESCRIPTION
Adding agents on top of everything propagates the agent properties to all jobs, including the one in the uploaded pipeline.
