### PR TITLE
Update derecho ncarenv version

### DIFF
--- a/cluster_environments/derecho.sh
+++ b/cluster_environments/derecho.sh
@@ -8,7 +8,7 @@ export NCAR_DEFAULT_INFOPATH="/usr/local/share/info:/usr/share/info"
 export NCAR_DEFAULT_MANPATH="/usr/local/share/man:/usr/share/man"
 export NCAR_DEFAULT_PATH="/usr/local/bin:/usr/bin:/sbin:/bin"
 export MODULEPATH="/glade/campaign/univ/ucit0011/ClimaModules-Derecho:/glade/u/apps/derecho/modules/environment"
-module load ncarenv/23.09
+module load ncarenv/24.12
 
 export PATH="/glade/campaign/univ/ucit0011/software/MPIwrapper/2024_05_27/bin/:$PATH"
 export TMPDIR="$TMPDIR/pbs-${PBS_JOBID}"


### PR DESCRIPTION
Derecho buildkite is currently broken because the new climacommon depends on ncarenv/24.12. This PR updates the version so that buildkite can load the newest climacommon.

See failing [build](https://buildkite.com/clima/climacalibrate-derecho/builds/57#01954e10-4a1a-4c79-97e9-1ac78efe6398)