### PR TITLE
Improve tempdir creation for Caltech HPC

### DIFF
--- a/cluster_environments/caltech_hpc.sh
+++ b/cluster_environments/caltech_hpc.sh
@@ -1,16 +1,28 @@
 #!/bin/bash
+set -euo pipefail
+
 export MODULEPATH="/groups/esm/modules:$MODULEPATH"
 module load git/2.39.3-gcc-11.3.1-zfr3sti
-set -x
-echo "SLURM_NODELIST: $SLURM_NODELIST"
 
-pdsh -w $SLURM_NODELIST mkdir -p "${TMPDIR}" || \
-srun --ntasks-per-node=1 --ntasks=${SLURM_JOB_NUM_NODES} mkdir -p "${TMPDIR}"    
+# Default TMPDIR if not set
+export TMPDIR="${TMPDIR:-/tmp/slurm-${SLURM_JOB_ID}}"
 
-# Check if TMPDIR was created
-pdsh -w "$SLURM_NODELIST" test -d "${TMPDIR}" || \
-srun --ntasks-per-node=1 --ntasks="${SLURM_JOB_NUM_NODES}" test -d "${TMPDIR}" || { \
-    echo "Error: Failed to create $TMPDIR"; exit 1; \
-}
+echo "Creating TMPDIR=$TMPDIR on all nodes: $SLURM_NODELIST"
 
-set +x
+# Create TMPDIR on all nodes
+srun --ntasks-per-node=1 --ntasks="${SLURM_JOB_NUM_NODES}" \
+    bash -c "mkdir -p '$TMPDIR' && chmod 700 '$TMPDIR'"
+if [ $? -ne 0 ]; then
+    echo "ERROR: Failed to create TMPDIR on one or more nodes" >&2
+    exit 1
+fi
+
+# Verify TMPDIR exists and is a directory on all nodes
+srun --ntasks-per-node=1 --ntasks="${SLURM_JOB_NUM_NODES}" \
+    bash -c "[ -d '$TMPDIR' ] || { echo \"Missing TMPDIR=$TMPDIR on \$(hostname)\" >&2; exit 1; }"
+if [ $? -ne 0 ]; then
+    echo "ERROR: TMPDIR verification failed on one or more nodes" >&2
+    exit 1
+fi
+
+echo "Successfully created TMPDIR=$TMPDIR on all nodes"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
Yesterday we started seeing [failures](https://buildkite.com/clima/climaland-ci/builds/7745#01975ab0-9287-4aa6-9932-f7779f07fd27) [related](https://buildkite.com/clima/climaatmos-ci/builds/24549#01975ac6-51ec-4647-9702-e66634177447) to the temporary directories created for each buildkite job. This PR makes the tempdir creation more robust. I think the usage of `pdsh` with the `srun` fallback in particular was causing this issue.

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
