### PR TITLE
allow extra artifacts on clima

### DIFF
--- a/bin/mirror.sh
+++ b/bin/mirror.sh
@@ -30,7 +30,8 @@ CLIMA_OVERRIDES="$CLIMA_DEST""Overrides.toml"
 # --exclude=".[!.]*" is to exclude dotfiles (e.g., NFS temporary files)
 rsync -av --omit-dir-times --exclude=".[!.]*" --exclude="*~" "$CENTRAL_SRC" "buildkite@clima.gps.caltech.edu:$CLIMA_DEST"
 
-# Second, we have to update the Overrides.toml on Clima
-ssh buildkite@clima.gps.caltech.edu "sed -i 's|/groups/esm/ClimaArtifacts/artifacts/|/net/sampo/data1/ClimaArtifacts/artifacts/|g' $CLIMA_OVERRIDES"
-
-
+# Second, we have to update the Overrides.toml on Clima and append any extra overrides we have for Clima
+ssh buildkite@clima.gps.caltech.edu "
+    sed -i 's|/groups/esm/ClimaArtifacts/artifacts/|/net/sampo/data1/ClimaArtifacts/artifacts/|g' '$CLIMA_OVERRIDES' &&
+    cat '$CLIMA_DEST/Overrides_extra.toml' >> '$CLIMA_OVERRIDES'
+"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The ERA5 forcing data exists only on clima, not central, since it's a very large artifact. This means it has an entry in the clima Overrides.toml, but not the central Overrides.toml. For the past couple of months, the weekly mirroring has overwritten this artifact's entry in the clima Overrides.toml, and we've had to manually fix it every week.

To avoid this continuing to happen, I added a new file Overrides_extra.toml which will live on clima and get appended to the end of the clima Overrides.toml file as part of the mirroring. For now it will only contain the ERA5 forcing data, but if we want to store additional artifacts only on clima (e.g. the CRUJRA forcing) we can add others there and they will be automatically added to the normal Overrides.toml each week.

This is also more reproducible/less prone to accidents since the path for the ERA5 forcing data is written down in a place that won't get overwritten.

## Content
- [x] add a file `Overrides_extra.toml` on clima (contents copied below)
- [x] add a command to append lines in this file to the clima `Overrides.toml` (this PR)

## Current contents of `Overrides_extra.toml`
```
# Forty years of ERA5 atmospheric forcing data, used by ClimaLand
f269a0b057b9f438b4caafdef17da73746310787 = "/net/sampo/data1/era5/forty_yrs_era5_land_forcing_data/forty_yrs_era5_land_forcing_data_artifact"
```

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
