### PR TITLE
Fix GCP env, add a3mega partition

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,16 +48,13 @@ steps:
   - label: "Test on GCP"
     command:
       - julia --project=.buildkite -e 'using Pkg; Pkg.instantiate()'
-      - julia --project=.buildkite -e 'using Pkg; Pkg.add("CUDA"); using CUDA; CUDA.set_runtime_version!(local_toolkit=true)'
-      - julia --project=.buildkite -e 'using Pkg; Pkg.add("MPIPreferences"); using MPIPreferences; use_system_binary(library_names="/sw/openmpi-5.0.5/lib/libmpi", mpiexec="/sw/openmpi-5.0.5/bin/mpiexec", force=true)'
-
       - mpiexec -n 2 nsys profile --trace=cuda,mpi --mpi-impl=openmpi --force-overwrite true julia --project=.buildkite .buildkite/test_cuda_mpi.jl
       - nsys stats --report cuda_gpu_trace report1.nsys-rep --force-export true
       - nsys stats --report cuda_gpu_trace report1.nsys-rep --force-export true | grep -E "memcpy (Peer-to-Peer|PtoP)"
     agents:
       queue: gcp
       slurm_ntasks: 2
-      slurm_gpus_per_task: 1
+      slurm_gpus: 2
       slurm_cpus_per_task: 4
       slurm_time: "00:10:00"
     soft_fail: true

--- a/bin/job_schedulers.py
+++ b/bin/job_schedulers.py
@@ -11,8 +11,8 @@ DEFAULT_SCHEDULER = os.environ.get('JOB_SYSTEM', 'slurm')
 DEFAULT_TIMELIMIT = '1:05:00'
 
 # Map from buildkite queue to slurm partition or PBS queue
-DEFAULT_PARTITIONS = {"gcp": "a3", "derecho": "preempt@desched1", "test": "batch", "clima": "batch", "central": "expansion"}
-DEFAULT_GPU_PARTITIONS = {"gcp": "a3", "derecho": "preempt@desched1", "test": "batch", "clima": "batch", "central": "gpu"}
+DEFAULT_PARTITIONS = {"gcp": "a3,a3mega", "derecho": "preempt@desched1", "test": "batch", "clima": "batch", "central": "expansion"}
+DEFAULT_GPU_PARTITIONS = {"gcp": "a3,a3mega", "derecho": "preempt@desched1", "test": "batch", "clima": "batch", "central": "gpu"}
 
 # Map from buildkite queue to HPC reservation
 DEFAULT_RESERVATIONS = { "central": "clima_cpu", "derecho": "UCIT0011"}

--- a/cluster_environments/gcp.sh
+++ b/cluster_environments/gcp.sh
@@ -2,21 +2,35 @@ set -euo pipefail
 
 source /opt/apps/lmod/lmod/init/bash
 
-# Set OpenMPI installation prefix (helps OpenMPI find its components)
-export OPAL_PREFIX="/sw/openmpi-5.0.5"
-# Add OpenMPI binaries to PATH (mpiexec, mpirun, etc.)
-export PATH="/sw/openmpi-5.0.5/bin:$PATH"
-# Add OpenMPI shared libraries to library search path
-export LD_LIBRARY_PATH="/sw/openmpi-5.0.5/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+unset CUDA_ROOT
+unset NVHPC_CUDA_HOME
+unset CUDA_INC_DIR
+unset CPATH
+unset NVHPC_ROOT 
 
-# Add CUDA binaries 
-export PATH="/usr/local/cuda/bin:$PATH"
-# Add Julia binaries
-export PATH="/home/ext_nefrathe_caltech_edu/sw/julia/julia-1.11.5/bin:$PATH"
-# Nsight
-export PATH="/home/ext_nefrathe_caltech_edu/sw/nsight/nsight-2025.3.1/bin:$PATH"
-# Enable UCX memory type caching for improved GPU memory handling performance
-export UCX_MEMTYPE_CACHE=y
+# NVHPC and HPC-X paths
+export NVHPC=/sw/nvhpc/Linux_x86_64/24.5
+export HPCX_PATH=$NVHPC/comm_libs/12.4/hpcx/hpcx-2.19
+
+# CUDA environment
+export CUDA_HOME=$NVHPC/cuda/12.4
+export CUDA_PATH=$CUDA_HOME
+export CUDA_ROOT=$CUDA_HOME
+
+# MPI via MPIwrapper
+export MPITRAMPOLINE_LIB="/sw/mpiwrapper/lib/libmpiwrapper.so"
+export OPAL_PREFIX=$HPCX_PATH/ompi
+
+# Library paths - CUDA first, then HPC-X
+export LD_LIBRARY_PATH="${CUDA_HOME}/lib64:${HPCX_PATH}/ompi/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+# Executable paths
+export PATH=/sw/mpiwrapper/bin:$CUDA_HOME/bin:$PATH
+export PATH="$NVHPC/profilers/Nsight_Systems/target-linux-x64:$PATH"
+
+# Julia
+export PATH="/sw/julia/julia-1.11.5/bin:$PATH"
+export JULIA_MPI_HAS_CUDA=true
 
 echo "Creating TMPDIR=$TMPDIR on all nodes: $SLURM_NODELIST"
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->
This PR changes the GCP queue to use a newly built CUDA-aware MPI version and adds the a3mega partition as an option for the job scheduler.


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->

Removed from environment:
- OpenMPI 5.0.5
- Direct CUDA setup
- UCX memory cache setting

Added:
- NVHPC environment with CUDA-aware MPI
- MPIWrapper 
- Ensured CUDA env variables were unset


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
