### PR TITLE
exclude CRUJRA artifact from rsync

### DIFF
--- a/bin/mirror.sh
+++ b/bin/mirror.sh
@@ -28,9 +28,8 @@ CLIMA_OVERRIDES="$CLIMA_DEST""Overrides.toml"
 
 # --omit-dir-times as in https://stackoverflow.com/a/668049
 # --exclude=".[!.]*" is to exclude dotfiles (e.g., NFS temporary files)
-rsync -av --omit-dir-times --exclude=".[!.]*" --exclude="*~" "$CENTRAL_SRC" "buildkite@clima.gps.caltech.edu:$CLIMA_DEST"
+# --exclude="crujra_forcing_data/" is to skip the very large CRUJRA forcing artifact
+rsync -av --omit-dir-times --exclude=".[!.]*" --exclude="*~" --exclude="crujra_forcing_data/" "$CENTRAL_SRC" "buildkite@clima.gps.caltech.edu:$CLIMA_DEST"
 
 # Second, we have to update the Overrides.toml on Clima
 ssh buildkite@clima.gps.caltech.edu "sed -i 's|/groups/esm/ClimaArtifacts/artifacts/|/net/sampo/data1/ClimaArtifacts/artifacts/|g' $CLIMA_OVERRIDES"
-
-


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
The CRUJRA artifact is very large (~500GB). Anytime it's included in the mirror.sh `rsync` command, it times out because this artifact takes 2+hours to sync. Currently the datafiles on central and sampo have different timestamps, so the rsync tries to copy it over each week. This change excludes this artifact from the rsync altogether.

Note that with this change, any updates to the CRUJRA artifact will have to be done on both central and clima to keep the two versions in sync.
