### PR TITLE
don't prepend # to slack-upload channel ID

### DIFF
--- a/bin/slack-upload
+++ b/bin/slack-upload
@@ -48,11 +48,6 @@ while getopts :c:f:s:hm:n:vx: OPT; do
   esac
 done
 
-# Prepend a # to the Slack channel name if it doesn't have one
-if [[ ( "${CHANNEL}" != "#"* ) && ( "${CHANNEL}" != "@"* ) ]]; then
-  CHANNEL="#${CHANNEL}"
-fi
-
 # Get the size of the file in bytes
 FILESIZE=$(stat -c%s "$FILENAME")
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
`slack-upload` previously used channel names, but now it uses channel IDs. Before, it would check if the channel name started with `#`, and prepend that character if not. I forgot to remove this in #94, so it errors with `{"ok":false,"error":"channel_not_found"}` ([build here](https://buildkite.com/clima/climacoupler-cpu-gpu-benchmarks/builds/269#019ad322-dedd-4dde-a422-50265e7a42ae))

## Content
- [x] remove the section of code that prepends `#` to the channel ID