### PR TITLE
Shallow clone for checkout, simplify retry logic

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -5,27 +5,22 @@ set -v
 
 if [ ! -d "${BUILDKITE_BUILD_CHECKOUT_PATH}/.git" ]; then
     echo "--- Init clone and checkout" 
-    COUNT=1
-    while true; do
-        git clone ${BUILDKITE_GIT_CLONE_FLAGS} ${BUILDKITE_REPO} "${BUILDKITE_BUILD_CHECKOUT_PATH}"
-        if [ $? -eq 0 ]; then
-            break
-        fi
-        if [[ $COUNT -ge 3 ]]; then
-            echo "Clone ${BUILDKITE_REPO} failed after 3 attempts"
-            exit 1
-        else
-            echo "Clone ${BUILDKITE_REPO} failed, retrying..."
-            sleep 30s
-        fi 
-        let COUNT=COUNT+1
-    done
-    cd "${BUILDKITE_BUILD_CHECKOUT_PATH}"
     if [ "$BUILDKITE_COMMIT" = "HEAD" ]; then
-        git checkout -f "${BUILDKITE_BRANCH}"
+        git clone \
+            --depth=1 \
+            --branch "${BUILDKITE_BRANCH}" \
+            ${BUILDKITE_GIT_CLONE_FLAGS} \
+            ${BUILDKITE_REPO} \
+            "${BUILDKITE_BUILD_CHECKOUT_PATH}"
     else
-        git checkout -f "${BUILDKITE_COMMIT}"
+        git clone \
+            --branch "${BUILDKITE_BRANCH}" \
+            ${BUILDKITE_GIT_CLONE_FLAGS} \
+            ${BUILDKITE_REPO} \
+            "${BUILDKITE_BUILD_CHECKOUT_PATH}"
     fi
+    cd "${BUILDKITE_BUILD_CHECKOUT_PATH}"
+    git checkout -f "${BUILDKITE_COMMIT}"
     # emulate https://github.com/buildkite/agent/blob/7e0166eebed5bf3cc289edae97145803429e75f9/bootstrap/bootstrap.go#L1448-L1458
     if ! buildkite-agent meta-data exists "buildkite:git:commit" ; then
         echo "Sending Git commit information to Buildkite"


### PR DESCRIPTION
This PR updates the checkout hook to remove the unused retry logic and only shallow clone repositories if we are checking out the HEAD of a given branch. This will help reduce failures if a cluster has high latency, causing jobs to time out when cloning repositories.