### PR TITLE
Add support for PRs from forks

### DIFF
--- a/hooks/checkout
+++ b/hooks/checkout
@@ -4,19 +4,20 @@ set -euo pipefail # exit on failure or unset variable
 set -v
 
 if [ ! -d "${BUILDKITE_BUILD_CHECKOUT_PATH}/.git" ]; then
-    echo "--- Init clone and checkout" 
+    echo "--- Init clone and checkout"
+    # use bash param expansion to support PRs from forks, and manually triggered builds where the pr repo is not set
     if [ "$BUILDKITE_COMMIT" = "HEAD" ]; then
         git clone \
             --depth=1 \
             --branch "${BUILDKITE_BRANCH}" \
             ${BUILDKITE_GIT_CLONE_FLAGS} \
-            ${BUILDKITE_REPO} \
+            "${BUILDKITE_PULL_REQUEST_REPO:-${BUILDKITE_REPO}}" \
             "${BUILDKITE_BUILD_CHECKOUT_PATH}"
     else
         git clone \
             --branch "${BUILDKITE_BRANCH}" \
             ${BUILDKITE_GIT_CLONE_FLAGS} \
-            ${BUILDKITE_REPO} \
+            "${BUILDKITE_PULL_REQUEST_REPO:-${BUILDKITE_REPO}}" \
             "${BUILDKITE_BUILD_CHECKOUT_PATH}"
     fi
     cd "${BUILDKITE_BUILD_CHECKOUT_PATH}"


### PR DESCRIPTION
towards #81

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
When an external contributor opens a PR from a fork, buildkite cannot check it out.



## Content
- if the build is from a PR, use that PRs repo. A CliMA org member should still need to manually trigger the run. This setting to auto-build PRs from forks is in the buildkite web-interface, but I'm not sure it should be enabled.

## TODO
To test, maybe temporarily make the change on clima.
<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
