### PR TITLE
Apply small fixes for improved scheduling

### DIFF
--- a/bin/job_schedulers.py
+++ b/bin/job_schedulers.py
@@ -60,6 +60,23 @@ def get_gpu_count(slurm_keys):
     # Default to 1 (only called when GPU is requested, so we need at least 1)
     return 1
 
+# Determine the explicitly-requested GPU type from slurm_gres, if any
+def get_gpu_type(slurm_keys):
+    """
+    Return the GPU type from an explicit slurm_gres tag, e.g.
+    'gpu:p100:4' -> 'p100', 'gpu:nvidia_l40s:1' -> 'nvidia_l40s'.
+    Returns None if slurm_gres is unset or specifies no type (e.g. 'gpu:1'),
+    in which case the queue's default GPU type applies.
+    """
+    gres = slurm_keys.get('slurm_gres')
+    if not gres:
+        return None
+    parts = gres.split(':')
+    # gpu:<type>:<count> -> parts[1] is the type; gpu:<count> has no type
+    if len(parts) >= 3:
+        return parts[1]
+    return None
+
 class JobScheduler:
     def submit_job(self, logger, build_log_dir, job):
         raise NotImplementedError("Subclass must implement submit_job")
@@ -84,11 +101,18 @@ class SlurmJobScheduler(JobScheduler):
             f"--output={joinpath(build_log_dir, 'slurm-%j.log')}",
         ]
         slurm_keys = {k: v for k, v in tags.items() if k.startswith('slurm_')}
+        default_gpu_type = DEFAULT_GPU_TYPES.get(queue)
 
-        # No reservation, add default if job has < 3 GPUs. Larger jobs can 
+        # No reservation, add default if job has < 3 GPUs. Larger jobs can
+        # run outside the reservation. Don't attach the GPU reservation to a job
+        # that explicitly requests a different GPU type (e.g. L40S): it can never
+        # run on the reservation's nodes, and would otherwise sit at the head of
+        # the queue holding a reservation it can't use.
         if 'slurm_reservation' not in slurm_keys and queue not in NO_RESERVATION_QUEUES:
             if gpu_is_requested(slurm_keys) and get_gpu_count(slurm_keys) < 3:
-                slurm_keys['slurm_reservation'] = DEFAULT_GPU_RESERVATIONS[queue]
+                gpu_type = get_gpu_type(slurm_keys)
+                if default_gpu_type is None or gpu_type is None or gpu_type == default_gpu_type:
+                    slurm_keys['slurm_reservation'] = DEFAULT_GPU_RESERVATIONS[queue]
             elif not gpu_is_requested(slurm_keys):
                 slurm_keys['slurm_reservation'] = DEFAULT_RESERVATIONS[queue]
         # Key exists and reservation == false, remove reservation
@@ -97,7 +121,6 @@ class SlurmJobScheduler(JobScheduler):
 
         # If the queue has a default GPU type, set --gres=gpu:type:N
         # Only add if user hasn't explicitly set gres
-        default_gpu_type = DEFAULT_GPU_TYPES.get(queue)
         if gpu_is_requested(slurm_keys) and default_gpu_type and 'slurm_gres' not in slurm_keys:
             gpu_count = get_gpu_count(slurm_keys)
             slurm_keys['slurm_gres'] = f"gpu:{default_gpu_type}:{gpu_count}"

--- a/bin/poll.py
+++ b/bin/poll.py
@@ -10,6 +10,7 @@ handler.setFormatter(formatter)
 logger.addHandler(handler)
 
 import os
+import re
 from datetime import date
 from os.path import join as joinpath
 
@@ -20,12 +21,38 @@ import job_schedulers
 # Time window to query buildkite jobs
 NHOURS = 96
 
+# Max concurrent Slurm jobs (pending + running) per buildkite pipeline slug.
+# All jobs share one service account, so a single pipeline flooding the queue
+# with high-priority (often un-runnable) jobs can consume the entire per-user
+# backfill window (bf_max_job_user) and starve every other pipeline. Capping
+# per-pipeline occupancy keeps the shared window populated with runnable work.
+# A job over the cap is left 'scheduled' in buildkite and reconsidered next poll.
+# Per-pipeline overrides go in PIPELINE_LIMITS; everything else uses the default.
+DEFAULT_PIPELINE_LIMIT = float("inf")  # no cap unless the pipeline is listed below
+PIPELINE_LIMITS = {
+    "oceananigans-distributed": 3,
+}
+
+def pipeline_slug_from_url(url):
+    """Extract the buildkite pipeline slug from a job/build web_url, e.g.
+    'https://buildkite.com/clima/climacoupler-ci/builds/9247#...' -> 'climacoupler-ci'."""
+    match = re.search(r'buildkite\.com/[^/]+/([^/?#]+)', url or '')
+    return match.group(1) if match else None
+
 try:
     scheduler = job_schedulers.get_job_scheduler()
 
     current_jobs = scheduler.current_jobs(logger)
     logger.info(f"Current jobs (submitted or started): {len(current_jobs)}")
     logger.debug(f"Current jobs: {current_jobs}")
+
+    # Count active (submitted + running) Slurm jobs per pipeline, so we can
+    # enforce per-pipeline concurrency caps below. Updated in-loop as we submit.
+    pipeline_counts = {}
+    for url, slurm_ids in current_jobs.items():
+        slug = pipeline_slug_from_url(url)
+        if slug:
+            pipeline_counts[slug] = pipeline_counts.get(slug, 0) + len(slurm_ids)
 
     # poll the buildkite API to check if there are any scheduled/running builds
     builds = all_started_builds(NHOURS)
@@ -90,8 +117,19 @@ try:
                 logger.error(f"New job missing queue. Pipeline: {pipeline_name}, {buildkite_url}")
                 continue
             elif queue == BUILDKITE_QUEUE:
+                # Enforce per-pipeline concurrency cap. A deferred job stays
+                # 'scheduled' in buildkite and is reconsidered on the next poll.
+                slug = pipeline_slug_from_url(buildkite_url)
+                limit = PIPELINE_LIMITS.get(slug, DEFAULT_PIPELINE_LIMIT)
+                if limit is not None and pipeline_counts.get(slug, 0) >= limit:
+                    logger.info(
+                        f"Deferring job, pipeline '{slug}' at cap {limit}: {buildkite_url}"
+                    )
+                    continue
                 logger.info(f"New job: {pipeline_name}, {buildkite_url}")
                 scheduler.submit_job(logger, log_dir, job)
+                # Count this submission so the cap holds within a single poll pass
+                pipeline_counts[slug] = pipeline_counts.get(slug, 0) + 1
 
     # Cancel jobs in canceled builds
     canceled_builds = all_canceled_builds()


### PR DESCRIPTION
Content
- Don't set GPU reservation unless the matching GPU type is requested
- Add per-pipeline concurrency limits. currently only applies to `oceananigans-distributed` with 3 concurrent builds.