### PR TITLE
Make Buildkite organization and default Slurm partition configurable via env

### DIFF
--- a/bin/buildkite.py
+++ b/bin/buildkite.py
@@ -5,7 +5,8 @@ import os
 import re
 from os.path import join as joinpath, isfile
 
-BUILDS_ENDPOINT = 'https://api.buildkite.com/v2/organizations/clima/builds'
+BUILDKITE_ORGANIZATION = os.environ.get('BUILDKITE_ORGANIZATION', 'clima')
+BUILDS_ENDPOINT = f'https://api.buildkite.com/v2/organizations/{BUILDKITE_ORGANIZATION}/builds'
 
 BUILDKITE_PATH = os.environ['BUILDKITE_PATH']
 BUILDKITE_QUEUE = os.environ['BUILDKITE_QUEUE']

--- a/bin/job_schedulers.py
+++ b/bin/job_schedulers.py
@@ -13,6 +13,7 @@ DEFAULT_TIMELIMIT = '1:05:00'
 # Map from buildkite queue to slurm partition or PBS queue
 DEFAULT_PARTITIONS = {"gcp": "a3,a3mega", "derecho": "preempt@desched1", "test": "batch", "clima": "batch", "central": "expansion"}
 DEFAULT_GPU_PARTITIONS = {"gcp": "a3,a3mega", "derecho": "preempt@desched1", "test": "batch", "clima": "batch", "central": "gpu"}
+DEFAULT_PARTITION = os.environ.get("SLURM_DEFAULT_PARTITION", "default")
 
 # Map from buildkite queue to HPC reservation
 DEFAULT_RESERVATIONS = { "central": "clima_cpu", "derecho": "UCIT0011"}
@@ -270,9 +271,9 @@ class SlurmJobScheduler(JobScheduler):
         # Set partition depending on if a GPU has been requested
         # Fallback to 'default' if there is no default partition
         if gpu_is_requested(slurm_keys):
-            default_partition = DEFAULT_GPU_PARTITIONS[queue]
+            default_partition = DEFAULT_GPU_PARTITIONS.get(queue, DEFAULT_PARTITION)
         else:
-            default_partition = DEFAULT_PARTITIONS[queue]
+            default_partition = DEFAULT_PARTITIONS.get(queue, DEFAULT_PARTITION)
 
         agent_partition = tags.get('partition', default_partition)
         cmd.append(f"--partition={agent_partition}")

--- a/set_up_guide.md
+++ b/set_up_guide.md
@@ -35,6 +35,8 @@ This is the configuration file for the Buildkite agent.
 Add an entry for the `case` statement using your cluster's hostname. If there are multiple nodes, you may want to use a regex to match all possible hostnames.
 Within the entry, set `BUILDKITE_PATH` and `BUILDKITE_QUEUE`. `BUILDKITE_PATH` is the path to your slurm-buildkite folder. `BUILDKITE_QUEUE` is your cluster's Buildkite queue name and it is used to filter for the jobs that will run on your cluster.
 
+Optionally set `BUILDKITE_ORGANIZATION` (defaults to `clima`) if your pipelines live in a different Buildkite organization; it is used to build the builds-API URL, so no source edit is needed to point at another org.
+
 Lastly, check if an extra bashrc_location is needed.
 
 #### bin/job_schedulers.py
@@ -44,6 +46,8 @@ Add entries for:
 - `DEFAULT_GPU_PARTITIONS`: Map from buildkite queue to GPU slurm partition or PBS queue
 - `DEFAULT_RESERVATIONS`: Map from buildkite queue to HPC reservation name
 - `NO_RESERVATION_QUEUES`: For clusters with no default reservations
+
+Queues that are not present in `DEFAULT_PARTITIONS` / `DEFAULT_GPU_PARTITIONS` fall back to the `SLURM_DEFAULT_PARTITION` environment variable (default `default`). A cluster with a single partition can just set `SLURM_DEFAULT_PARTITION` instead of editing the maps.
 
 
 #### hooks/environment


### PR DESCRIPTION
## Summary

Two small, backward-compatible changes so `slurm-buildkite` can run in a Buildkite organization other than `clima` and on clusters whose partitions aren't in the built-in map — **without editing the source**. Defaults preserve current behavior.

### 1. Configurable Buildkite organization
`bin/buildkite.py` hardcoded the org in `BUILDS_ENDPOINT`:
```python
BUILDS_ENDPOINT = 'https://api.buildkite.com/v2/organizations/clima/builds'
```
It now reads `BUILDKITE_ORGANIZATION` (defaulting to `clima`), mirroring the existing `BUILDKITE_QUEUE` / `BUILDKITE_PATH` env pattern. Any other org previously required editing this line.

### 2. Default-partition fallback (fixes a latent `KeyError`)
`SlurmJobScheduler.submit_job` computed the default partition by direct indexing:
```python
default_partition = DEFAULT_PARTITIONS[queue]
```
The adjacent comment says *"Fallback to 'default' if there is no default partition"*, but the eager index raises `KeyError` for any queue not in `DEFAULT_PARTITIONS` / `DEFAULT_GPU_PARTITIONS` — and it does so **before** the `tags.get('partition', ...)` override can take effect, so a deployment on a new queue crashes even if its pipeline steps set `agents: {partition: ...}`.

Changed to `.get(queue, DEFAULT_PARTITION)`, where `DEFAULT_PARTITION` comes from `SLURM_DEFAULT_PARTITION` (default `"default"`). Known queues are unchanged; unknown queues now fall back to the configured default (matching the existing comment) and per-step `partition` tags work as intended.

## Testing
- `python3 -m py_compile bin/buildkite.py bin/job_schedulers.py` passes.
- Verified against a live non-`clima` deployment

## Notes
Both env vars default to today's behavior, so existing CliMA deployments need no action.
