### PR TITLE
Add agent-token-only metrics-poll mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ Some clusters are not web-accessible, so we are unable to use webhooks to schedu
 
 Unlike regular Buildkite builds, we don't run each job in an isolated environment, so the checkout only happens on the first job (usually the pipeline upload) and the state is shared between all jobs in the build.
 
+### Agent-token-only mode
+
+The REST-based polling above requires a Buildkite *user* API token. Orgs that are only issued a cluster *agent* token can instead set `BUILDKITE_POLL_MODE=metrics`, which switches [`bin/poll.py`](https://github.com/CliMA/slurm-buildkite/blob/master/bin/poll.py) to [`bin/metrics_poll.py`](https://github.com/CliMA/slurm-buildkite/blob/master/bin/metrics_poll.py). This mode polls Buildkite's Agent Metrics API for each queue's scheduled-job and idle/busy-agent counts, and launches generic agents (via [`bin/schedule_agent.sh`](https://github.com/CliMA/slurm-buildkite/blob/master/bin/schedule_agent.sh), sized from the queue's name rather than per-job tags) to close the gap. See the "Agent-token-only mode" section of the [set-up guide](https://github.com/CliMA/slurm-buildkite/blob/master/set_up_guide.md) for configuration details.
+
 
 ## Passing options to Slurm
 

--- a/bin/metrics_poll.py
+++ b/bin/metrics_poll.py
@@ -1,0 +1,166 @@
+import os
+import re
+import subprocess
+from os.path import join as joinpath, isfile
+
+import requests
+
+from job_schedulers import DEFAULT_PARTITIONS, DEFAULT_GPU_PARTITIONS, DEFAULT_GPU_TYPES
+
+BUILDKITE_PATH = os.environ['BUILDKITE_PATH']
+BUILDKITE_QUEUE = os.environ['BUILDKITE_QUEUE']
+
+METRICS_ENDPOINT = 'https://agent.buildkite.com/v3/metrics/queue'
+
+# Queues to watch, comma-separated. Defaults to the single queue this cluster
+# already runs the REST-mode poller against.
+BUILDKITE_QUEUES = [
+    q.strip() for q in
+    os.environ.get('BUILDKITE_QUEUES', BUILDKITE_QUEUE).split(',')
+    if q.strip()
+]
+
+# Cap on new agents submitted per queue per poll, so a metrics spike (or a bug
+# in this script) can't flood the Slurm queue in one pass.
+MAX_AGENTS_PER_QUEUE = int(os.environ.get('MAX_AGENTS_PER_QUEUE', '10'))
+
+SLURM_TIMELIMIT = os.environ.get('SLURM_TIMELIMIT', '01:05:00')
+SLURM_QOS = os.environ.get('SLURM_QOS')
+# Override the queue-name-derived GPU type for every queue, if set.
+SLURM_GPU_TYPE_OVERRIDE = os.environ.get('SLURM_GPU_TYPE')
+
+# Queue name convention for GPU sizing: '<base>_<N>gpu' requests N GPUs on
+# partition/type looked up for '<base>' in job_schedulers' maps; a bare queue
+# name with no suffix is treated as CPU-only. This lets metrics-mode reuse the
+# same per-cluster maps REST-mode already maintains instead of a second config
+# surface.
+QUEUE_GPU_SUFFIX = re.compile(r'^(?P<base>.+)_(?P<count>\d+)gpu$')
+
+
+def _agent_token():
+    """Resolve the Buildkite cluster agent token: BUILDKITE_AGENT_TOKEN env
+    var, or the `token=` line out of the agent config every cluster already
+    has for running `buildkite-agent start` (see set_up_guide.md). Unlike
+    REST mode's BUILDKITE_API_TOKEN, no *user* API token is ever required."""
+    token = os.environ.get('BUILDKITE_AGENT_TOKEN')
+    if token:
+        return token
+
+    cfg_path = joinpath(BUILDKITE_PATH, 'buildkite-agent.cfg')
+    if isfile(cfg_path):
+        with open(cfg_path, 'r') as f:
+            for line in f:
+                match = re.match(r'^\s*token\s*=\s*"?([^"\s]+)"?\s*$', line)
+                if match:
+                    return match.group(1)
+
+    raise RuntimeError(
+        'No agent token found: set BUILDKITE_AGENT_TOKEN or add a token= '
+        f'line to {cfg_path}'
+    )
+
+
+def _queue_gpu_spec(queue):
+    """Return (base_queue, gpu_count) for a queue name, per the '<base>_<N>gpu'
+    convention. gpu_count is 0 for a bare queue name (CPU-only)."""
+    match = QUEUE_GPU_SUFFIX.match(queue)
+    if match:
+        return match.group('base'), int(match.group('count'))
+    return queue, 0
+
+
+def _queue_metrics(logger, token, queue):
+    """Fetch {scheduled, idle, busy} for one queue from the Agent Metrics API."""
+    resp = requests.get(
+        METRICS_ENDPOINT,
+        params={'name': queue},
+        headers={'Authorization': f'Token {token}'},
+    )
+    resp.raise_for_status()
+    data = resp.json()
+    jobs = data.get('jobs', {})
+    agents = data.get('agents', {})
+    return {
+        'scheduled': jobs.get('scheduled', 0),
+        'idle': agents.get('idle', 0),
+        'busy': agents.get('busy', 0),
+    }
+
+
+def _pending_slurm_agents(queue):
+    """Count Slurm jobs for this queue's generic agents that are still PENDING
+    (i.e. haven't registered as a Buildkite agent yet, so the Metrics API
+    can't see them). Without this, a backed-up Slurm queue reads as `have = 0`
+    every poll and gets flooded with duplicate submissions."""
+    job_name = f'bk-metrics-{queue}'
+    out = subprocess.run(
+        ['squeue', '-h', '--name', job_name, '--states=PENDING', '--noheader'],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    ).stdout.decode('utf-8')
+    return sum(1 for line in out.splitlines() if line.strip())
+
+
+def _submit_generic_agent(logger, queue):
+    base_queue, gpu_count = _queue_gpu_spec(queue)
+
+    cmd = [
+        'sbatch',
+        '--parsable',
+        f'--job-name=bk-metrics-{queue}',
+        f'--time={SLURM_TIMELIMIT}',
+    ]
+
+    if gpu_count > 0:
+        gpu_type = SLURM_GPU_TYPE_OVERRIDE or DEFAULT_GPU_TYPES.get(base_queue)
+        gres = f'gpu:{gpu_type}:{gpu_count}' if gpu_type else f'gpu:{gpu_count}'
+        cmd.append(f'--gres={gres}')
+        partition = DEFAULT_GPU_PARTITIONS.get(base_queue)
+    else:
+        partition = DEFAULT_PARTITIONS.get(base_queue)
+
+    if partition:
+        cmd.append(f'--partition={partition}')
+    if SLURM_QOS:
+        cmd.append(f'--qos={SLURM_QOS}')
+
+    # BUILDKITE_PATH is passed positionally, not inherited from the submitting
+    # shell's environment: some Slurm variants don't reliably propagate env
+    # vars into the batch script.
+    cmd.append(joinpath(BUILDKITE_PATH, 'bin/schedule_agent.sh'))
+    cmd.append(queue)
+    cmd.append(BUILDKITE_PATH)
+
+    logger.debug(f"Slurm command: {' '.join(cmd)}")
+    try:
+        result = subprocess.run(
+            cmd, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            universal_newlines=True,
+        )
+        logger.info(f"Submitted generic agent for queue '{queue}', Slurm job {result.stdout.strip()}")
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Slurm error submitting generic agent for queue '{queue}': {e.stderr}")
+
+
+def run(logger):
+    token = _agent_token()
+
+    for queue in BUILDKITE_QUEUES:
+        try:
+            metrics = _queue_metrics(logger, token, queue)
+            pending = _pending_slurm_agents(queue)
+
+            need = metrics['scheduled']
+            have = metrics['idle'] + metrics['busy'] + pending
+
+            to_submit = max(0, min(need - have, MAX_AGENTS_PER_QUEUE))
+            logger.info(
+                f"Queue '{queue}': need={need} have={have} "
+                f"(idle={metrics['idle']}, busy={metrics['busy']}, pending={pending}), "
+                f"submitting {to_submit}"
+            )
+
+            for _ in range(to_submit):
+                _submit_generic_agent(logger, queue)
+
+        except Exception:
+            logger.error(f"Caught exception while polling queue '{queue}'", exc_info=True)

--- a/bin/poll.py
+++ b/bin/poll.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+import logging
+# setup root logger
+logger = logging.Logger('poll')
+handler = logging.StreamHandler()
+# For debug statements: handler.setLevel(logging.DEBUG)
+handler.setLevel(logging.INFO)
+formatter = logging.Formatter('%(asctime)s - %(levelname)s: %(message)s')
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
 import os
 
 # Which poller implementation to run: 'rest' (default) polls the Buildkite
@@ -11,14 +21,6 @@ import os
 BUILDKITE_POLL_MODE = os.environ.get('BUILDKITE_POLL_MODE', 'rest')
 
 if BUILDKITE_POLL_MODE == 'metrics':
-    import logging
-    logger = logging.Logger('poll')
-    handler = logging.StreamHandler()
-    handler.setLevel(logging.INFO)
-    formatter = logging.Formatter('%(asctime)s - %(levelname)s: %(message)s')
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-
     import metrics_poll
     try:
         metrics_poll.run(logger)
@@ -26,16 +28,6 @@ if BUILDKITE_POLL_MODE == 'metrics':
         logger.error("Caught exception during metrics poll", exc_info=True)
 
 else:
-    import logging
-    # setup root logger
-    logger = logging.Logger('poll')
-    handler = logging.StreamHandler()
-    # For debug statements: handler.setLevel(logging.DEBUG)
-    handler.setLevel(logging.INFO)
-    formatter = logging.Formatter('%(asctime)s - %(levelname)s: %(message)s')
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
-
     import re
     from datetime import date
     from os.path import join as joinpath

--- a/bin/poll.py
+++ b/bin/poll.py
@@ -1,150 +1,176 @@
 #!/usr/bin/env python3
-import logging
-# setup root logger
-logger = logging.Logger('poll')
-handler = logging.StreamHandler()
-# For debug statements: handler.setLevel(logging.DEBUG)
-handler.setLevel(logging.INFO)
-formatter = logging.Formatter('%(asctime)s - %(levelname)s: %(message)s')
-handler.setFormatter(formatter)
-logger.addHandler(handler)
-
 import os
-import re
-from datetime import date
-from os.path import join as joinpath
 
-from buildkite import all_started_builds, all_canceled_builds, build_url
-from buildkite import get_buildkite_job_tags, BUILDKITE_PATH, BUILDKITE_QUEUE
-import job_schedulers
+# Which poller implementation to run: 'rest' (default) polls the Buildkite
+# builds REST API and requires a user API token; 'metrics' polls the agent
+# Metrics API and requires only a cluster agent token (see metrics_poll.py).
+# Deferring the mode-specific imports below (rather than importing both
+# unconditionally) matters: importing `buildkite` eagerly requires a user API
+# token / `.buildkite_token` file, which orgs running metrics-only mode may
+# not have at all.
+BUILDKITE_POLL_MODE = os.environ.get('BUILDKITE_POLL_MODE', 'rest')
 
-# Time window to query buildkite jobs
-NHOURS = 96
+if BUILDKITE_POLL_MODE == 'metrics':
+    import logging
+    logger = logging.Logger('poll')
+    handler = logging.StreamHandler()
+    handler.setLevel(logging.INFO)
+    formatter = logging.Formatter('%(asctime)s - %(levelname)s: %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
 
-# Max concurrent Slurm jobs (pending + running) per buildkite pipeline slug.
-# All jobs share one service account, so a single pipeline flooding the queue
-# with high-priority (often un-runnable) jobs can consume the entire per-user
-# backfill window (bf_max_job_user) and starve every other pipeline. Capping
-# per-pipeline occupancy keeps the shared window populated with runnable work.
-# A job over the cap is left 'scheduled' in buildkite and reconsidered next poll.
-# Per-pipeline overrides go in PIPELINE_LIMITS; everything else uses the default.
-DEFAULT_PIPELINE_LIMIT = float("inf")  # no cap unless the pipeline is listed below
-PIPELINE_LIMITS = {
-    "oceananigans-distributed": 3,
-}
+    import metrics_poll
+    try:
+        metrics_poll.run(logger)
+    except Exception:
+        logger.error("Caught exception during metrics poll", exc_info=True)
 
-def pipeline_slug_from_url(url):
-    """Extract the buildkite pipeline slug from a job/build web_url, e.g.
-    'https://buildkite.com/clima/climacoupler-ci/builds/9247#...' -> 'climacoupler-ci'."""
-    match = re.search(r'buildkite\.com/[^/]+/([^/?#]+)', url or '')
-    return match.group(1) if match else None
+else:
+    import logging
+    # setup root logger
+    logger = logging.Logger('poll')
+    handler = logging.StreamHandler()
+    # For debug statements: handler.setLevel(logging.DEBUG)
+    handler.setLevel(logging.INFO)
+    formatter = logging.Formatter('%(asctime)s - %(levelname)s: %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
 
-try:
-    scheduler = job_schedulers.get_job_scheduler()
+    import re
+    from datetime import date
+    from os.path import join as joinpath
 
-    current_jobs = scheduler.current_jobs(logger)
-    logger.info(f"Current jobs (submitted or started): {len(current_jobs)}")
-    logger.debug(f"Current jobs: {current_jobs}")
+    from buildkite import all_started_builds, all_canceled_builds, build_url
+    from buildkite import get_buildkite_job_tags, BUILDKITE_PATH, BUILDKITE_QUEUE
+    import job_schedulers
 
-    # Count active (submitted + running) Slurm jobs per pipeline, so we can
-    # enforce per-pipeline concurrency caps below. Updated in-loop as we submit.
-    pipeline_counts = {}
-    for url, slurm_ids in current_jobs.items():
-        slug = pipeline_slug_from_url(url)
-        if slug:
-            pipeline_counts[slug] = pipeline_counts.get(slug, 0) + len(slurm_ids)
+    # Time window to query buildkite jobs
+    NHOURS = 96
 
-    # poll the buildkite API to check if there are any scheduled/running builds
-    builds = all_started_builds(NHOURS)
+    # Max concurrent Slurm jobs (pending + running) per buildkite pipeline slug.
+    # All jobs share one service account, so a single pipeline flooding the queue
+    # with high-priority (often un-runnable) jobs can consume the entire per-user
+    # backfill window (bf_max_job_user) and starve every other pipeline. Capping
+    # per-pipeline occupancy keeps the shared window populated with runnable work.
+    # A job over the cap is left 'scheduled' in buildkite and reconsidered next poll.
+    # Per-pipeline overrides go in PIPELINE_LIMITS; everything else uses the default.
+    DEFAULT_PIPELINE_LIMIT = float("inf")  # no cap unless the pipeline is listed below
+    PIPELINE_LIMITS = {
+        "oceananigans-distributed": 3,
+    }
 
-    # Accumulate jobs to be canceled in one batch 
-    jobs_to_cancel = []
-    # loop over all scheduled and running builds for all pipelines in the buildkite org
-    for build in builds:
+    def pipeline_slug_from_url(url):
+        """Extract the buildkite pipeline slug from a job/build web_url, e.g.
+        'https://buildkite.com/clima/climacoupler-ci/builds/9247#...' -> 'climacoupler-ci'."""
+        match = re.search(r'buildkite\.com/[^/]+/([^/?#]+)', url or '')
+        return match.group(1) if match else None
 
-        pipeline = build['pipeline']
-        pipeline_name = pipeline['name']
+    try:
+        scheduler = job_schedulers.get_job_scheduler()
 
-        # for all jobs in this build
-        for job in build['jobs']:
+        current_jobs = scheduler.current_jobs(logger)
+        logger.info(f"Current jobs (submitted or started): {len(current_jobs)}")
+        logger.debug(f"Current jobs: {current_jobs}")
 
-            # jobid, jobtype are attributes in every job object
-            jobid, jobtype = job['id'], job['type']
+        # Count active (submitted + running) Slurm jobs per pipeline, so we can
+        # enforce per-pipeline concurrency caps below. Updated in-loop as we submit.
+        pipeline_counts = {}
+        for url, slurm_ids in current_jobs.items():
+            slug = pipeline_slug_from_url(url)
+            if slug:
+                pipeline_counts[slug] = pipeline_counts.get(slug, 0) + len(slurm_ids)
 
-            # don't schedule non-script jobs on slurm
-            if jobtype != 'script':
-                continue
+        # poll the buildkite API to check if there are any scheduled/running builds
+        builds = all_started_builds(NHOURS)
 
-            # this job is a script job, check if it has a scheduled state
-            # and not submitted as slurm job
-            # valid states: running, scheduled, passed, failed, blocked,
-            #               canceled, canceling, skipped, not_run, finished
-            # https://buildkite.com/docs/pipelines/defining-steps#build-states
-            jobstate = job['state']
-            buildkite_url = job['web_url']
+        # Accumulate jobs to be canceled in one batch
+        jobs_to_cancel = []
+        # loop over all scheduled and running builds for all pipelines in the buildkite org
+        for build in builds:
 
-            # Cancel jobs marked by buildkite as 'canceled'
-            if jobstate == 'canceled':
-                if buildkite_url in current_jobs:
-                    logger.debug(f"Cancel job: {buildkite_url}")
-                    jobs_to_cancel.append(current_jobs[buildkite_url])
-                continue
+            pipeline = build['pipeline']
+            pipeline_name = pipeline['name']
 
-            # jobstate is not pending, or a scheduled job (but not running yet)
-            # is already submitted to slurm
-            if jobstate != 'scheduled' or buildkite_url in current_jobs:
-                continue
+            # for all jobs in this build
+            for job in build['jobs']:
 
-            # Directory containing slurm logs for given build
-            log_dir = joinpath(
-                BUILDKITE_PATH,
-                'logs',
-                f'{date.today()}',
-                f"build_{build['id']}",
-            )
+                # jobid, jobtype are attributes in every job object
+                jobid, jobtype = job['id'], job['type']
 
-            job_tags = get_buildkite_job_tags(job)
-            queue = job_tags.get('queue', None)
-
-            # Create the directory prefix if it does not exist
-            if not os.path.isdir(log_dir):
-                build_link = build_url(pipeline_name, build['number'])
-                logger.info(f"New build on `{queue}`: {pipeline_name} - {build_link}")
-                os.mkdir(log_dir)
-
-            # Only log jobs on current queue unless debugging or missing queue
-            if queue is None:
-                logger.error(f"New job missing queue. Pipeline: {pipeline_name}, {buildkite_url}")
-                continue
-            elif queue == BUILDKITE_QUEUE:
-                # Enforce per-pipeline concurrency cap. A deferred job stays
-                # 'scheduled' in buildkite and is reconsidered on the next poll.
-                slug = pipeline_slug_from_url(buildkite_url)
-                limit = PIPELINE_LIMITS.get(slug, DEFAULT_PIPELINE_LIMIT)
-                if limit is not None and pipeline_counts.get(slug, 0) >= limit:
-                    logger.info(
-                        f"Deferring job, pipeline '{slug}' at cap {limit}: {buildkite_url}"
-                    )
+                # don't schedule non-script jobs on slurm
+                if jobtype != 'script':
                     continue
-                logger.info(f"New job: {pipeline_name}, {buildkite_url}")
-                scheduler.submit_job(logger, log_dir, job)
-                # Count this submission so the cap holds within a single poll pass
-                pipeline_counts[slug] = pipeline_counts.get(slug, 0) + 1
 
-    # Cancel jobs in canceled builds
-    canceled_builds = all_canceled_builds()
-
-    for build in canceled_builds:
-        for job in build['jobs']:
-            if job['type'] == 'script':
+                # this job is a script job, check if it has a scheduled state
+                # and not submitted as slurm job
+                # valid states: running, scheduled, passed, failed, blocked,
+                #               canceled, canceling, skipped, not_run, finished
+                # https://buildkite.com/docs/pipelines/defining-steps#build-states
+                jobstate = job['state']
                 buildkite_url = job['web_url']
-                if buildkite_url in current_jobs:
-                    jobs_to_cancel.append(current_jobs[buildkite_url])
 
-    # Cancel individually marked hpc jobs in one call
-    if jobs_to_cancel:
-        logger.debug(f"Jobs to cancel: {jobs_to_cancel}")
-        scheduler.cancel_jobs(logger, jobs_to_cancel)
+                # Cancel jobs marked by buildkite as 'canceled'
+                if jobstate == 'canceled':
+                    if buildkite_url in current_jobs:
+                        logger.debug(f"Cancel job: {buildkite_url}")
+                        jobs_to_cancel.append(current_jobs[buildkite_url])
+                    continue
 
-except Exception:
-    logger.error("Caught exception during poll",  exc_info=True)
+                # jobstate is not pending, or a scheduled job (but not running yet)
+                # is already submitted to slurm
+                if jobstate != 'scheduled' or buildkite_url in current_jobs:
+                    continue
+
+                # Directory containing slurm logs for given build
+                log_dir = joinpath(
+                    BUILDKITE_PATH,
+                    'logs',
+                    f'{date.today()}',
+                    f"build_{build['id']}",
+                )
+
+                job_tags = get_buildkite_job_tags(job)
+                queue = job_tags.get('queue', None)
+
+                # Create the directory prefix if it does not exist
+                if not os.path.isdir(log_dir):
+                    build_link = build_url(pipeline_name, build['number'])
+                    logger.info(f"New build on `{queue}`: {pipeline_name} - {build_link}")
+                    os.mkdir(log_dir)
+
+                # Only log jobs on current queue unless debugging or missing queue
+                if queue is None:
+                    logger.error(f"New job missing queue. Pipeline: {pipeline_name}, {buildkite_url}")
+                    continue
+                elif queue == BUILDKITE_QUEUE:
+                    # Enforce per-pipeline concurrency cap. A deferred job stays
+                    # 'scheduled' in buildkite and is reconsidered on the next poll.
+                    slug = pipeline_slug_from_url(buildkite_url)
+                    limit = PIPELINE_LIMITS.get(slug, DEFAULT_PIPELINE_LIMIT)
+                    if limit is not None and pipeline_counts.get(slug, 0) >= limit:
+                        logger.info(
+                            f"Deferring job, pipeline '{slug}' at cap {limit}: {buildkite_url}"
+                        )
+                        continue
+                    logger.info(f"New job: {pipeline_name}, {buildkite_url}")
+                    scheduler.submit_job(logger, log_dir, job)
+                    # Count this submission so the cap holds within a single poll pass
+                    pipeline_counts[slug] = pipeline_counts.get(slug, 0) + 1
+
+        # Cancel jobs in canceled builds
+        canceled_builds = all_canceled_builds()
+
+        for build in canceled_builds:
+            for job in build['jobs']:
+                if job['type'] == 'script':
+                    buildkite_url = job['web_url']
+                    if buildkite_url in current_jobs:
+                        jobs_to_cancel.append(current_jobs[buildkite_url])
+
+        # Cancel individually marked hpc jobs in one call
+        if jobs_to_cancel:
+            logger.debug(f"Jobs to cancel: {jobs_to_cancel}")
+            scheduler.cancel_jobs(logger, jobs_to_cancel)
+
+    except Exception:
+        logger.error("Caught exception during poll",  exc_info=True)

--- a/bin/poll.py
+++ b/bin/poll.py
@@ -13,156 +13,17 @@ import os
 
 # Which poller implementation to run: 'rest' (default) polls the Buildkite
 # builds REST API and requires a user API token; 'metrics' polls the agent
-# Metrics API and requires only a cluster agent token (see metrics_poll.py).
-# Deferring the mode-specific imports below (rather than importing both
-# unconditionally) matters: importing `buildkite` eagerly requires a user API
-# token / `.buildkite_token` file, which orgs running metrics-only mode may
-# not have at all.
+# Metrics API and requires only a cluster agent token. Each mode lives in its
+# own module (rest_poll.py / metrics_poll.py), imported lazily here so that
+# rest_poll's eager user-token requirement is never hit when running in
+# metrics-only mode.
 BUILDKITE_POLL_MODE = os.environ.get('BUILDKITE_POLL_MODE', 'rest')
 
-if BUILDKITE_POLL_MODE == 'metrics':
-    import metrics_poll
-    try:
-        metrics_poll.run(logger)
-    except Exception:
-        logger.error("Caught exception during metrics poll", exc_info=True)
-
-else:
-    import re
-    from datetime import date
-    from os.path import join as joinpath
-
-    from buildkite import all_started_builds, all_canceled_builds, build_url
-    from buildkite import get_buildkite_job_tags, BUILDKITE_PATH, BUILDKITE_QUEUE
-    import job_schedulers
-
-    # Time window to query buildkite jobs
-    NHOURS = 96
-
-    # Max concurrent Slurm jobs (pending + running) per buildkite pipeline slug.
-    # All jobs share one service account, so a single pipeline flooding the queue
-    # with high-priority (often un-runnable) jobs can consume the entire per-user
-    # backfill window (bf_max_job_user) and starve every other pipeline. Capping
-    # per-pipeline occupancy keeps the shared window populated with runnable work.
-    # A job over the cap is left 'scheduled' in buildkite and reconsidered next poll.
-    # Per-pipeline overrides go in PIPELINE_LIMITS; everything else uses the default.
-    DEFAULT_PIPELINE_LIMIT = float("inf")  # no cap unless the pipeline is listed below
-    PIPELINE_LIMITS = {
-        "oceananigans-distributed": 3,
-    }
-
-    def pipeline_slug_from_url(url):
-        """Extract the buildkite pipeline slug from a job/build web_url, e.g.
-        'https://buildkite.com/clima/climacoupler-ci/builds/9247#...' -> 'climacoupler-ci'."""
-        match = re.search(r'buildkite\.com/[^/]+/([^/?#]+)', url or '')
-        return match.group(1) if match else None
-
-    try:
-        scheduler = job_schedulers.get_job_scheduler()
-
-        current_jobs = scheduler.current_jobs(logger)
-        logger.info(f"Current jobs (submitted or started): {len(current_jobs)}")
-        logger.debug(f"Current jobs: {current_jobs}")
-
-        # Count active (submitted + running) Slurm jobs per pipeline, so we can
-        # enforce per-pipeline concurrency caps below. Updated in-loop as we submit.
-        pipeline_counts = {}
-        for url, slurm_ids in current_jobs.items():
-            slug = pipeline_slug_from_url(url)
-            if slug:
-                pipeline_counts[slug] = pipeline_counts.get(slug, 0) + len(slurm_ids)
-
-        # poll the buildkite API to check if there are any scheduled/running builds
-        builds = all_started_builds(NHOURS)
-
-        # Accumulate jobs to be canceled in one batch
-        jobs_to_cancel = []
-        # loop over all scheduled and running builds for all pipelines in the buildkite org
-        for build in builds:
-
-            pipeline = build['pipeline']
-            pipeline_name = pipeline['name']
-
-            # for all jobs in this build
-            for job in build['jobs']:
-
-                # jobid, jobtype are attributes in every job object
-                jobid, jobtype = job['id'], job['type']
-
-                # don't schedule non-script jobs on slurm
-                if jobtype != 'script':
-                    continue
-
-                # this job is a script job, check if it has a scheduled state
-                # and not submitted as slurm job
-                # valid states: running, scheduled, passed, failed, blocked,
-                #               canceled, canceling, skipped, not_run, finished
-                # https://buildkite.com/docs/pipelines/defining-steps#build-states
-                jobstate = job['state']
-                buildkite_url = job['web_url']
-
-                # Cancel jobs marked by buildkite as 'canceled'
-                if jobstate == 'canceled':
-                    if buildkite_url in current_jobs:
-                        logger.debug(f"Cancel job: {buildkite_url}")
-                        jobs_to_cancel.append(current_jobs[buildkite_url])
-                    continue
-
-                # jobstate is not pending, or a scheduled job (but not running yet)
-                # is already submitted to slurm
-                if jobstate != 'scheduled' or buildkite_url in current_jobs:
-                    continue
-
-                # Directory containing slurm logs for given build
-                log_dir = joinpath(
-                    BUILDKITE_PATH,
-                    'logs',
-                    f'{date.today()}',
-                    f"build_{build['id']}",
-                )
-
-                job_tags = get_buildkite_job_tags(job)
-                queue = job_tags.get('queue', None)
-
-                # Create the directory prefix if it does not exist
-                if not os.path.isdir(log_dir):
-                    build_link = build_url(pipeline_name, build['number'])
-                    logger.info(f"New build on `{queue}`: {pipeline_name} - {build_link}")
-                    os.mkdir(log_dir)
-
-                # Only log jobs on current queue unless debugging or missing queue
-                if queue is None:
-                    logger.error(f"New job missing queue. Pipeline: {pipeline_name}, {buildkite_url}")
-                    continue
-                elif queue == BUILDKITE_QUEUE:
-                    # Enforce per-pipeline concurrency cap. A deferred job stays
-                    # 'scheduled' in buildkite and is reconsidered on the next poll.
-                    slug = pipeline_slug_from_url(buildkite_url)
-                    limit = PIPELINE_LIMITS.get(slug, DEFAULT_PIPELINE_LIMIT)
-                    if limit is not None and pipeline_counts.get(slug, 0) >= limit:
-                        logger.info(
-                            f"Deferring job, pipeline '{slug}' at cap {limit}: {buildkite_url}"
-                        )
-                        continue
-                    logger.info(f"New job: {pipeline_name}, {buildkite_url}")
-                    scheduler.submit_job(logger, log_dir, job)
-                    # Count this submission so the cap holds within a single poll pass
-                    pipeline_counts[slug] = pipeline_counts.get(slug, 0) + 1
-
-        # Cancel jobs in canceled builds
-        canceled_builds = all_canceled_builds()
-
-        for build in canceled_builds:
-            for job in build['jobs']:
-                if job['type'] == 'script':
-                    buildkite_url = job['web_url']
-                    if buildkite_url in current_jobs:
-                        jobs_to_cancel.append(current_jobs[buildkite_url])
-
-        # Cancel individually marked hpc jobs in one call
-        if jobs_to_cancel:
-            logger.debug(f"Jobs to cancel: {jobs_to_cancel}")
-            scheduler.cancel_jobs(logger, jobs_to_cancel)
-
-    except Exception:
-        logger.error("Caught exception during poll",  exc_info=True)
+try:
+    if BUILDKITE_POLL_MODE == 'metrics':
+        import metrics_poll as poll_impl
+    else:
+        import rest_poll as poll_impl
+    poll_impl.run(logger)
+except Exception:
+    logger.error(f"Caught exception during {BUILDKITE_POLL_MODE} poll", exc_info=True)

--- a/bin/rest_poll.py
+++ b/bin/rest_poll.py
@@ -1,0 +1,136 @@
+import os
+import re
+from datetime import date
+from os.path import join as joinpath
+
+from buildkite import all_started_builds, all_canceled_builds, build_url
+from buildkite import get_buildkite_job_tags, BUILDKITE_PATH, BUILDKITE_QUEUE
+import job_schedulers
+
+# Time window to query buildkite jobs
+NHOURS = 96
+
+# Max concurrent Slurm jobs (pending + running) per buildkite pipeline slug.
+# All jobs share one service account, so a single pipeline flooding the queue
+# with high-priority (often un-runnable) jobs can consume the entire per-user
+# backfill window (bf_max_job_user) and starve every other pipeline. Capping
+# per-pipeline occupancy keeps the shared window populated with runnable work.
+# A job over the cap is left 'scheduled' in buildkite and reconsidered next poll.
+# Per-pipeline overrides go in PIPELINE_LIMITS; everything else uses the default.
+DEFAULT_PIPELINE_LIMIT = float("inf")  # no cap unless the pipeline is listed below
+PIPELINE_LIMITS = {
+    "oceananigans-distributed": 3,
+}
+
+def pipeline_slug_from_url(url):
+    """Extract the buildkite pipeline slug from a job/build web_url, e.g.
+    'https://buildkite.com/clima/climacoupler-ci/builds/9247#...' -> 'climacoupler-ci'."""
+    match = re.search(r'buildkite\.com/[^/]+/([^/?#]+)', url or '')
+    return match.group(1) if match else None
+
+def run(logger):
+    scheduler = job_schedulers.get_job_scheduler()
+
+    current_jobs = scheduler.current_jobs(logger)
+    logger.info(f"Current jobs (submitted or started): {len(current_jobs)}")
+    logger.debug(f"Current jobs: {current_jobs}")
+
+    # Count active (submitted + running) Slurm jobs per pipeline, so we can
+    # enforce per-pipeline concurrency caps below. Updated in-loop as we submit.
+    pipeline_counts = {}
+    for url, slurm_ids in current_jobs.items():
+        slug = pipeline_slug_from_url(url)
+        if slug:
+            pipeline_counts[slug] = pipeline_counts.get(slug, 0) + len(slurm_ids)
+
+    # poll the buildkite API to check if there are any scheduled/running builds
+    builds = all_started_builds(NHOURS)
+
+    # Accumulate jobs to be canceled in one batch
+    jobs_to_cancel = []
+    # loop over all scheduled and running builds for all pipelines in the buildkite org
+    for build in builds:
+
+        pipeline = build['pipeline']
+        pipeline_name = pipeline['name']
+
+        # for all jobs in this build
+        for job in build['jobs']:
+
+            # jobid, jobtype are attributes in every job object
+            jobid, jobtype = job['id'], job['type']
+
+            # don't schedule non-script jobs on slurm
+            if jobtype != 'script':
+                continue
+
+            # this job is a script job, check if it has a scheduled state
+            # and not submitted as slurm job
+            # valid states: running, scheduled, passed, failed, blocked,
+            #               canceled, canceling, skipped, not_run, finished
+            # https://buildkite.com/docs/pipelines/defining-steps#build-states
+            jobstate = job['state']
+            buildkite_url = job['web_url']
+
+            # Cancel jobs marked by buildkite as 'canceled'
+            if jobstate == 'canceled':
+                if buildkite_url in current_jobs:
+                    logger.debug(f"Cancel job: {buildkite_url}")
+                    jobs_to_cancel.append(current_jobs[buildkite_url])
+                continue
+
+            # jobstate is not pending, or a scheduled job (but not running yet)
+            # is already submitted to slurm
+            if jobstate != 'scheduled' or buildkite_url in current_jobs:
+                continue
+
+            # Directory containing slurm logs for given build
+            log_dir = joinpath(
+                BUILDKITE_PATH,
+                'logs',
+                f'{date.today()}',
+                f"build_{build['id']}",
+            )
+
+            job_tags = get_buildkite_job_tags(job)
+            queue = job_tags.get('queue', None)
+
+            # Create the directory prefix if it does not exist
+            if not os.path.isdir(log_dir):
+                build_link = build_url(pipeline_name, build['number'])
+                logger.info(f"New build on `{queue}`: {pipeline_name} - {build_link}")
+                os.mkdir(log_dir)
+
+            # Only log jobs on current queue unless debugging or missing queue
+            if queue is None:
+                logger.error(f"New job missing queue. Pipeline: {pipeline_name}, {buildkite_url}")
+                continue
+            elif queue == BUILDKITE_QUEUE:
+                # Enforce per-pipeline concurrency cap. A deferred job stays
+                # 'scheduled' in buildkite and is reconsidered on the next poll.
+                slug = pipeline_slug_from_url(buildkite_url)
+                limit = PIPELINE_LIMITS.get(slug, DEFAULT_PIPELINE_LIMIT)
+                if limit is not None and pipeline_counts.get(slug, 0) >= limit:
+                    logger.info(
+                        f"Deferring job, pipeline '{slug}' at cap {limit}: {buildkite_url}"
+                    )
+                    continue
+                logger.info(f"New job: {pipeline_name}, {buildkite_url}")
+                scheduler.submit_job(logger, log_dir, job)
+                # Count this submission so the cap holds within a single poll pass
+                pipeline_counts[slug] = pipeline_counts.get(slug, 0) + 1
+
+    # Cancel jobs in canceled builds
+    canceled_builds = all_canceled_builds()
+
+    for build in canceled_builds:
+        for job in build['jobs']:
+            if job['type'] == 'script':
+                buildkite_url = job['web_url']
+                if buildkite_url in current_jobs:
+                    jobs_to_cancel.append(current_jobs[buildkite_url])
+
+    # Cancel individually marked hpc jobs in one call
+    if jobs_to_cancel:
+        logger.debug(f"Jobs to cancel: {jobs_to_cancel}")
+        scheduler.cancel_jobs(logger, jobs_to_cancel)

--- a/bin/schedule_agent.sh
+++ b/bin/schedule_agent.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Companion to schedule_job.sh, but for metrics-poll mode: this launches a
+# generic Buildkite agent that picks up whatever job comes next on $QUEUE,
+# rather than being tied to one job UUID via --acquire-job. $BUILDKITE_PATH is
+# passed positionally (see metrics_poll.py) rather than inherited, since some
+# Slurm variants don't propagate env vars into batch scripts reliably.
+QUEUE="$1"
+BUILDKITE_PATH="$2"
+
+PATH="${BUILDKITE_PATH}/bin:$PATH"
+
+"${BUILDKITE_PATH}/bin/buildkite-agent" start \
+  --name "$QUEUE-generic-%n" \
+  --config "${BUILDKITE_PATH}/buildkite-agent.cfg" \
+  --tags "queue=$QUEUE" \
+  --disconnect-after-job \
+  --disconnect-after-idle-timeout=60

--- a/set_up_guide.md
+++ b/set_up_guide.md
@@ -66,6 +66,19 @@ Ensure that previously created TMPDIRs. As before, this can either be done with 
 #### Optional: hooks/pre-command
 - Ensure that output folders have proper permissions
 
+### Optional: Agent-token-only mode
+
+By default `bin/poll.py` polls Buildkite's builds REST API, which requires a *user* API token (`.buildkite_token`, step above). Some orgs are only issued a Buildkite **cluster agent token** and have no user API token available at all. For those, `bin/poll.py` supports a second mode that polls Buildkite's [Agent Metrics API](https://buildkite.com/docs/agent/v3/cli-start#agent-metrics) instead, using only the agent token already configured in `buildkite-agent.cfg`.
+
+To enable it, set in your `bin/cron.sh` case entry:
+- `BUILDKITE_POLL_MODE=metrics`
+- `BUILDKITE_QUEUES` — comma-separated list of Buildkite queues to watch (defaults to `BUILDKITE_QUEUE`)
+- Optionally `MAX_AGENTS_PER_QUEUE` (default `10`), `SLURM_QOS`, `SLURM_TIMELIMIT` (default `01:05:00`), `SLURM_GPU_TYPE`
+
+Because there's no per-job data available from the Metrics API, agents launched in this mode are generic (they pick up whatever job is next on the queue, rather than a specific job via `--acquire-job`), and GPU sizing comes from the queue name instead of per-job tags: a queue named `<base>_<N>gpu` (e.g. `central_2gpu`) requests `N` GPUs on the partition/GPU type configured for `<base>` in `bin/job_schedulers.py`; a bare queue name (no suffix) is treated as CPU-only.
+
+Note for some Slurm variants (e.g. those that copy batch scripts to a spool directory before running them): environment variables set by the submitting shell are not always propagated into the batch script. `bin/metrics_poll.py` works around this by passing `BUILDKITE_PATH` as a positional argument to `bin/schedule_agent.sh` rather than relying on env inheritance — keep this in mind if you extend this mode further.
+
 ### Testing
 
 You can test this setup by setting the `BUILDKITE_QUEUE` to `test` and manually running the cronjob `bin/cron.sh`. Logs from the cron job will be written to `logs/YYYY-MM-DD/cron`. 


### PR DESCRIPTION
﻿## Summary

Closes #124.

Some Buildkite orgs are only issued a **cluster agent token** (`bkct_...`), not a user API token (`bkua_...`). `bin/poll.py` currently requires a user API token to list builds via the REST API, so those orgs can''t use this repo''s Slurm/PBS bridge at all -- even though agents themselves register and run jobs fine with just the agent token.

This PR adds a second, opt-in poller mode that authenticates with only the agent token, by polling Buildkite''s [Agent Metrics API](https://buildkite.com/docs/agent/v3/cli-start#agent-metrics) instead of the builds REST API, and launching generic ephemeral agents sized from queue-name convention instead of per-job tags.

## What''s new

- **`BUILDKITE_POLL_MODE`** env var (`rest` default / `metrics`) -- `bin/poll.py` is now a thin dispatcher that lazily imports either `rest_poll.py` (existing behavior, extracted verbatim, unchanged) or `metrics_poll.py`. The REST path is untouched and remains the default, so no existing deployment needs to change anything.
- **`bin/metrics_poll.py`** -- for each queue in `BUILDKITE_QUEUES`:
  - Authenticates with `BUILDKITE_AGENT_TOKEN`, falling back to the `token=` line already in `buildkite-agent.cfg` -- no new credential file needed.
  - Queries `GET https://agent.buildkite.com/v3/metrics/queue?name=<queue>` for `scheduled`/`idle`/`busy` counts.
  - Computes `need = scheduled`, `have = idle + busy + pending` (`pending` = Slurm jobs for this queue still `PENDING`, via `squeue`, since the Metrics API can''t see agents that haven''t registered yet -- without this a backed-up Slurm queue would read `have = 0` and get flooded every poll).
  - Submits `min(need - have, MAX_AGENTS_PER_QUEUE)` generic agents per queue.
  - Sizes GPUs from a queue-name convention (`<base>_<N>gpu`, e.g. `central_2gpu`), looked up against the partition/GPU-type maps `job_schedulers.py` already maintains, rather than a second config surface.
- **`bin/schedule_agent.sh`** -- companion to `schedule_job.sh`, but starts a generic `buildkite-agent` (`--disconnect-after-job`, `--disconnect-after-idle-timeout`) that picks up whatever job is next on its queue, instead of `--acquire-job <uuid>`.
- **`bin/rest_poll.py`** -- the existing REST-mode logic, moved out of `poll.py` verbatim behind a `run(logger)` function, so both modes share the same interface and `poll.py` doesn''t have to inline one branch''s implementation.
- Docs: `set_up_guide.md` gets an "Agent-token-only mode" section (env vars, queue-naming convention, a note on `BUILDKITE_PATH` being passed positionally rather than via env, since some Slurm variants don''t propagate env vars into batch scripts reliably); `README.md`''s Design section gets a short paragraph on the new mode.
